### PR TITLE
Todo #1

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -588,7 +588,7 @@ not required to do so.
 - getters/setters can be replaced by properties, depending on what is
 customary in the language in which the library is implemented
 
-- the root of the class hierarchy is called `Object` in this document
+
 
 ### JobExecutor
 

--- a/specification.md
+++ b/specification.md
@@ -94,9 +94,6 @@ nicely, with a metadata dictionary.
 - [x] Add a get_version method/function with a note about version obj vs
 string depending on programming  language
 
-- [x] add ability to have custom attributes which could be passed to the
-underlying LRM (aka. dynamic attributes).
-
 - [x] merge prev() spirit into previous method (the order)
 
 - [ ] "canceled" or "cancelled"?
@@ -107,6 +104,9 @@ distinguish between EAGAIN types of errors and others.
 - [ ] think more about env var expansion in arguments and other places.
 The important issue is how much of a burden this is on implementations if
 we mandate it.
+
+- [ ] add ability to have custom attributes which could be passed to the
+underlying LRM (aka. dynamic attributes).
 
 - [ ] we need to go through the resource spec; many common things
 supported by other JM APIs are not supported by Flux Jobspec V1, such as
@@ -1315,19 +1315,6 @@ resources reserved through the advanced reservation represented by this
 ID.
 
 
-<a name="jobattributes-setcustomattribute"></a>
-```java
-void setCustomAttribute(String name, Object value);
-Object? getCustomAttribute(String name);
-```
-
-Allows setting/querying of custom attributes. Implementations should use a
-dictionary to implement the custom attributes. Additionally, implementations are
-encouraged to make sensible decisions on whether to store some or all of the
-fixed attributes in the same dictionary or not. It is, therefore, entirely
-possible for `getCustomAttribute("duration")` to return a value passed earlier
-to `setDuration()`, although the specific custom attribute name need not be
-`"duration"`.
 
 ### TimeInterval
 

--- a/specification.md
+++ b/specification.md
@@ -94,6 +94,9 @@ nicely, with a metadata dictionary.
 - [x] Add a get_version method/function with a note about version obj vs
 string depending on programming  language
 
+- [x] add ability to have custom attributes which could be passed to the
+underlying LRM (aka. dynamic attributes).
+
 - [ ] "canceled" or "cancelled"?
 
 - [ ] Consider adding further exceptions to submit() in order to
@@ -104,9 +107,6 @@ distinguish between EAGAIN types of errors and others.
 - [ ] think more about env var expansion in arguments and other places.
 The important issue is how much of a burden this is on implementations if
 we mandate it.
-
-- [ ] add ability to have custom attributes which could be passed to the
-underlying LRM (aka. dynamic attributes).
 
 - [ ] we need to go through the resource spec; many common things
 supported by other JM APIs are not supported by Flux Jobspec V1, such as
@@ -588,7 +588,7 @@ not required to do so.
 - getters/setters can be replaced by properties, depending on what is
 customary in the language in which the library is implemented
 
-
+- the root of the class hierarchy is called `Object` in this document
 
 ### JobExecutor
 
@@ -1306,6 +1306,19 @@ resources reserved through the advanced reservation represented by this
 ID.
 
 
+<a name="jobattributes-setcustomattribute"></a>
+```java
+void setCustomAttribute(String name, Object value);
+Object? getCustomAttribute(String name);
+```
+
+Allows setting/querying of custom attributes. Implementations should use a
+dictionary to implement the custom attributes. Additionally, implementations are
+encouraged to make sensible decisions on whether to store some or all of the
+fixed attributes in the same dictionary or not. It is, therefore, entirely
+possible for `getCustomAttribute("duration")` to return a value passed earlier
+to `setDuration()`, although the specific custom attribute name need not be
+`"duration"`.
 
 ### TimeInterval
 

--- a/specification.md
+++ b/specification.md
@@ -87,14 +87,14 @@ partial failures for bulk submission
 
 - [x] distinguish client-facing API from library-facing API
 
+- [x] Add metadata to JobStatus. One important use case we discussed is
+getting the native job ID when the job becomes QUEUED. Flux does this
+nicely, with a metadata dictionary.
+
 - [ ] "canceled" or "cancelled"?
 
 - [ ] Consider adding further exceptions to submit() in order to
 distinguish between EAGAIN types of errors and others.
-
-- [ ] Add metadata to JobStatus. One important use case we discussed is
-getting the native job ID when the job becomes QUEUED. Flux does this
-nicely, with a metadata dictionary.
 
 - [ ] Add a get_version method/function with a note about version obj vs
 string depending on programming  language
@@ -939,6 +939,18 @@ is expected to be provided by the standard library of the language in
 which the library is implemented. If such a class is not provided,
 implementations have the discretion of implementing a relevant
 `Timestamp` class.
+
+
+<a name="jobstatus-getmetdadata"></a>
+```java
+Dictionary<String, Object>? getMetadata()
+```
+
+Returns metadata associated with this status, if any. The content of the
+metadata dictionary is not mandated by this specification and is left to the
+implementation. Possible metadata entries include:
+
+* `native-id`: the native identifier used by the LRM for the job.
 
 
 <a name="jobstatus-getexitcode"></a>

--- a/specification.md
+++ b/specification.md
@@ -91,13 +91,13 @@ partial failures for bulk submission
 getting the native job ID when the job becomes QUEUED. Flux does this
 nicely, with a metadata dictionary.
 
+- [x] Add a get_version method/function with a note about version obj vs
+string depending on programming  language
+
 - [ ] "canceled" or "cancelled"?
 
 - [ ] Consider adding further exceptions to submit() in order to
 distinguish between EAGAIN types of errors and others.
-
-- [ ] Add a get_version method/function with a note about version obj vs
-string depending on programming  language
 
 - [ ] merge prev() spirit into previous method (the order)
 


### PR DESCRIPTION
Fixed some of the items in the TODO list. Specifically:

* Add metadata to JobStatus. One important use case we discussed is...
* Add a get_version method/function with a note about version obj vs string depending on programming  language
* add ability to have custom attributes which could be passed to the underlying LRM (aka. dynamic attributes).
* merge prev() spirit into previous method (the order)

I'm issuing this PR instead of waiting because it seems like the probability of conflicts is getting higher. In fact, we're already hitting a bit of a conflict with #1 

Anyway, please review, let's resolve the contentious parts, and merge the rest.