### PR TITLE
Fix callback example

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -328,7 +328,7 @@ asynchronous implementation can run multiple jobs in a single thread:
 ```java
 void runJobs() {
     jobsLeft = alljobs.size();
-    executor.addJobStatusCallback(new JobStatusCallback() {
+    executor.setJobStatusCallback(new JobStatusCallback() {
         jobStatusChanged(Job job, JobStatus status) {
             if (status.isTerminal()) {
                 jobsLeft--;


### PR DESCRIPTION
The first commit is just fixing a typo.

The second commit might be controversial depending on if it was intentional or not to make the job status callback setters for `Executor` and `Job` different.