### PR TITLE
change `overrideEnvironment` -> `inheritEnvironment`

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -659,10 +659,10 @@ arguments to the list by invoking `setArguments()` with a mutable list,
 then invoking `getArguments().add()`.
 
 
-<a name="jobspec-setoverrideenvironment"></a>
+<a name="jobspec-setinheritenvironment"></a>
 ```java
-void setOverrideEnvironment(boolean clearEnvironment)
-boolean getOverrideEnvironment()
+void setInheritEnvironment(boolean inheritEnvironment)
+boolean getInheritEnvironment()
 ```
 
 If this flag is set to `false`, the job starts with an empty environment.


### PR DESCRIPTION
As discussed in #93, the semantics of the `overrideEnvironment` flag are
OK, but the name doesn't immediately evoke the right semantics in many
minds.  Change the name to `inheritEnvironment` to hopefully evoke the
correct semantics in users' minds.

Closes #93