### PR TITLE
Add additional examples

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2077,6 +2077,42 @@ jex.submit(job)
 job.wait()
 ```
 
+#### Submit a job, check for transient error, retry if one occurred
+
+```python
+import time
+import math
+import random
+
+import jpsi
+
+def make_job():
+    job = jpsi.Job()
+    spec = jpsi.JobSpec()
+    spec.executable = '/bin/sleep'
+    spec.arguments = ['10']
+    job.specification = spec
+    return job
+
+def submit_with_exponential_backoff(jex, job):
+    times_attempted = 0
+    while(True):
+        try:
+            jex.submit(job)
+        except jpsi.SubmitException as se:
+            if not se.isTransient():
+                raise # re-raise to let caller see and handle it
+            times_attempted += 1
+            # https://en.wikipedia.org/wiki/Exponential_backoff
+            time.sleep(random.randint(0, math.pow(2, times_attempted) - 1))
+        else:
+            break
+
+jex = jpsi.JobExectorFactory.get_instance('slurm')
+job = make_job()
+submit_with_exponential_backoff(jex, job)
+job.wait()
+```
 
 
 ### Appendix D - Naming

--- a/specification.md
+++ b/specification.md
@@ -1959,6 +1959,28 @@ else:
 job_1.wait()
 ```
 
+#### Submit a job, wait for queued event, cancel then, and then wait for the final event
+
+```python
+import jpsi
+
+def make_job():
+    job = jpsi.Job()
+    spec = jpsi.JobSpec()
+    spec.executable = '/bin/sleep'
+    spec.arguments = ['10']
+    job.specification = spec
+    return job
+
+jex = jpsi.JobExectorFactory.get_instance('slurm')
+
+job = make_job()
+jex.submit(job)
+job.wait(JobState.QUEUED)
+job.cancel()
+job.wait()
+```
+
 
 #### Run a job with P total processes where each process gets C cpus and G gpus
 


### PR DESCRIPTION
#48 originally stated:
> I am assuming that whoever added this intended to track some "too many jobs in the queue" error from the LRM and act according to that. If so, it would be difficult to do this because we do not define a clear mechanism that could allow a clear way for a user to distinguish such an error from other errors. To state that differently, it's not impossible, but it isn't specified. One would have to rely on how the implementation happens to report errors of such type.

We don't have an explicit error for "too many jobs in the queue", but we do have a `isTransient` method for the `SubmitException`.  So I tweaked the example a bit to be a submission loop that continually attempts re-submission during transient issues using an exponential backoff algorithm.

Closes #18
Closes #48