### PR TITLE
Specify logging behavior

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -23,6 +23,8 @@
   - [The Job API; Layer 0](#the-job-api-layer-0)
     - [Implementation Notes](#implementation-notes)
       - [Interaction with LRMs and Scalability](#interaction-with-lrms-and-scalability)
+    - [Behavior](#behavior)
+      - [Logging](#logging)
     - [JobExecutor](#jobexecutor)
       - [Methods](#methods)
           - [Exceptions:](#exceptions)
@@ -288,6 +290,15 @@ query interfaces (e.g.,  `qstat -a`) to get the status of all jobs and
 extract the information about the relevant jobs from the result.
 
 </div>
+
+
+### Behavior
+
+#### Logging
+
+Implementations must not perform any logging that cannot be configured and
+disabled by users. Users may perform their own job-state logging by using the
+`addJobStatusCallback` methods of `JobExecutor` and `Job`.
 
 
 ### JobExecutor


### PR DESCRIPTION
Based on some discussion on #115 I thought it might be good to specify how implementations should handle logging. 

On the one hand, users can do whatever job-state logging they want using the `addStatusCallback` methods of `Job` and `JobExecutor`. On the other hand, depending on the language it might be a little painful to actually make them do that. For instance, in Python, the library could set up a [logging.handlers.NullHandler](https://docs.python.org/3/howto/logging.html#library-config) and then let users configure the library's logging behavior through the normal mechanisms.