### PR TITLE
Remove Job.getId() method

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -533,17 +533,6 @@ the above constructor, the job will be in the `NEW` state.
 
 #### Methods
 
-<a name="job-getid"></a>
-```java
-String getId()
-```
-
-Returns this job's ID. The ID is assigned automatically by the
-implementation when the Job object is constructed. The ID is guaranteed
-to be unique on the client machine. The ID does not have to match the ID
-of the underlying LRM job, but is used to identify `Job` instances as
-seen by a client application.
-
 
 <a name="job-setspec"></a>
 ```java


### PR DESCRIPTION
Since the `jobId` method has no defined usage, I think it should be removed. It could, of course, be very easily added back in if use-cases were found that really needed it. 

Logging is one proposed use-case. But since it seems to be agreed that you must attach to jobs using the native ID, I think any logs would be better off including the native ID.