### PR TITLE
Added a `Job.executor` property.

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -602,6 +602,20 @@ the above constructor, the job will be in the `NEW` state.
 
 #### Methods
 
+<a name="job-getexecutor"></a>
+```java
+void setExecutor(JobExecutor executor)
+JobExecutor? getExecutor()
+```
+
+Returns the [`JobExecutor`](#jobexecutor) that this job is bound to. An executor
+is bound to a job when the job is successfully submitted to the executor using
+[`JobExecutor.submit()`](#jobexecutor-submit) or attached to an existing native
+job using [`JobExecutor.attach()`](#jobexecutor-attach). It is the
+responsibility of the `JobExecutor` implementation to set this property on a job
+instance when that job is submitted or attached.
+
+
 <a name="job-getid"></a>
 ```java
 String getId()


### PR DESCRIPTION
Since `Job.cancel()` requires the job to hold an executor instance,
this property is implied but not explicit. Since jobs are submitted
using `JobExecutor.submit()`, the job does not get to see an executor
instance unless the executor explicitly communicattes a reference to
itself as part of the `submit()` call. However, if the property is not
defined in the spec, an executor implementation cannot know what property
to set unless it looks at the specifics of the implementation of the `Job`
class. But that also prevents the executor implementation from being
portable to other implementations of the PSI/J core classes.

An alternative solution might be to submit an attach jobs using 
`Job.submit(JobExecutor ex)` and `Job.attach(JobExecutor ex)`, but seems a 
bit forced given that the implementation of, say `Job.submit(ex)` would 
essentially be `this.executor = ex; ex.submit(this)`.