### PR TITLE
Added file staging

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -742,8 +742,8 @@ Furthermore, implementations must, to the extent possible, simulate missing
 states. For example, if the implementation polls a LRM queue infrequently 
 enough such that the active state of a job is skipped between two polling 
 rounds, the job would appear to have jumped from a `QUEUED` state to a 
-`COMPLETED` state. However, implementations can, for example, introduce a 
-synthetic `ACTIVE` state change.
+`COMPLETED` state. In such cases implementations must introduce a synthetic
+`ACTIVE` state change.
 
 
 

--- a/specification.md
+++ b/specification.md
@@ -865,7 +865,8 @@ JobSpec(name: str = None, executable: str = None,
         attributes: JobAttributes = None)
         stage_in: Optional[Set[StageIn]] = None,
         stage_out: Optional[Set[StageOut]] = None,
-        cleanup: Optional[Set[Path]] = None)
+        cleanup: Optional[Set[Path]] = None,
+        cleanup_flags: StageOutFlags = StageOutFlags.ALWAYS)
 ```
 
 Creates an instance of `JobSpec` which allows properties to be initialized
@@ -1106,6 +1107,16 @@ a set of files that are to be deleted once the job completes and all relevant
 files are staged out but before the job is marked as `COMPLETED` (or `FAILED`).
 
 
+<a name="jobspec-set_cleanup_flags"></a>
+```java
+void setCleanupFlags(StageOutFlags flags)
+StageOutFlags getCleanupFlags()
+```
+
+Allows the controlling of the circumstances under which cleanup should occur. 
+By default, this flag should be set to `StageOutFlags.ALWAYS`. The value
+`StageOutFlags.IF_PRESENT` is ignored and the absence of files in the cleanup
+set when the cleanup step occurs must not result in an error.
 
 ### JobStatus
 

--- a/specification.md
+++ b/specification.md
@@ -216,6 +216,12 @@ filesystem.
 - Assumes that the client application is executed in an environment that has 
 direct access (i.e., does not require authentication) to a local LRM.
 
+- Enables file staging to and from job directory
+
+- Enables file cleanup
+
+- [Allows for standard output/error streaming if supported by the executor]
+
 
 ### Layer 1 (remote)
 
@@ -230,13 +236,6 @@ direct access (i.e., does not require authentication) to a local LRM.
     - Authentication and authorization
 
     - Encryption
-
-- Enables file staging
-
-- Allows for standard output/error streaming
-
-- Enables file cleanup (an alternative and perhaps more flexible way of doing
-this is to implement pre- and post-jobs in Layer 0)
 
 - May require user mapping if a system-wide service is deployed. User mapping 
 is a mapping of the authenticated user to a local user under which the job

--- a/specification.md
+++ b/specification.md
@@ -332,10 +332,6 @@ explicit runtime type-checks, but it is not required to do so.
 - Getters/setters can be replaced by properties, depending on what is customary 
 in the language in which the library is implemented.
 
-- Implementations may elect, at their discretion, to implement many of the 
-classes described in this document as read-only classes for which all 
-properties are set at construction time. 
-
 
 <div class="imp-note">
 

--- a/specification.md
+++ b/specification.md
@@ -13,7 +13,7 @@
 
 
 - [A Portable Submission Interface for Jobs (PSI/J)](#a-portable-submission-interface-for-jobs-psij)
-  - [STATUS: EARLY DRAFT](#status-early-draft)
+  - [Current Version: 0.2](#current-version-02)
   - [Introduction](#introduction)
     - [A Note about Code Samples](#a-note-about-code-samples)
   - [Motivation and Design Goals](#motivation-and-design-goals)
@@ -85,7 +85,16 @@
 
 <!-- /TOC -->
 
-## STATUS: EARLY DRAFT
+## Current Version: 0.2
+
+Version 0.1:
+- initial version
+- specification for Layer 0
+
+Version 0.2:
+- moves file staging from Layer 1 to Layer 0
+- adds file staging
+
 
 
 

--- a/specification.md
+++ b/specification.md
@@ -863,8 +863,9 @@ JobSpec(name: str = None, executable: str = None,
         stdout_path: Path = None, stderr_path: Path = None,
         resources: ResourceSpec = None,
         attributes: JobAttributes = None)
-        stageIn: Optional[StageInSet] = None,
-        stageOut: Optional[StageOutSet] = None,
+        stage_in: Optional[Set[StageIn]] = None,
+        stage_out: Optional[Set[StageOut]] = None,
+        cleanup: Optional[Set[Cleanup]] = None)
 ```
 
 Creates an instance of `JobSpec` which allows properties to be initialized
@@ -1203,8 +1204,8 @@ This class represents an enumeration and has no public constructors.
 ```java
 boolean isGreaterThan(JobState other)
 ```
-
 Defines a partial ordering on the states. 
+
 
 It is not possible to compare two final states—otherwise all state pairs are 
 comparable. Comparisons are transitive. The order is:

--- a/specification.md
+++ b/specification.md
@@ -865,7 +865,7 @@ JobSpec(name: str = None, executable: str = None,
         attributes: JobAttributes = None)
         stage_in: Optional[Set[StageIn]] = None,
         stage_out: Optional[Set[StageOut]] = None,
-        cleanup: Optional[Set[Cleanup]] = None)
+        cleanup: Optional[Set[Path]] = None)
 ```
 
 Creates an instance of `JobSpec` which allows properties to be initialized

--- a/specification.md
+++ b/specification.md
@@ -867,6 +867,8 @@ JobSpec(name: str = None, executable: str = None,
         stdout_path: Path = None, stderr_path: Path = None,
         resources: ResourceSpec = None,
         attributes: JobAttributes = None)
+        stageIn: Optional[StageInSet] = None,
+        stageOut: Optional[StageOutSet] = None,
 ```
 
 Creates an instance of `JobSpec` which allows properties to be initialized

--- a/specification.md
+++ b/specification.md
@@ -21,7 +21,7 @@
     - [Layer 0 (local)](#layer-0-local)
     - [Layer 1 (remote)](#layer-1-remote)
     - [Layer 2 (nested)](#layer-2-nested)
-  - [The Job API; Layer 0](#the-job-api-layer-0)
+  - [The Job API](#the-job-api)
     - [Implementation Notes](#implementation-notes)
       - [Interaction with LRMs and Scalability](#interaction-with-lrms-and-scalability)
     - [JobExecutor](#jobexecutor)
@@ -258,10 +258,11 @@ infrastructure if implementation chose to have pilot management mechanisms.
 
 
 
-## The Job API; Layer 0
+## The Job API
 
-This section describes the most basic form of the PSI/J API, namely one in
-which the location of the backend is either implicit or local. The main
+This section describes the PSI/J API. Classes, properties, and methods from 
+Layer 1 are explicitly marked with a <sup>Layer 1</sup> superscript, whereas 
+Layer 0 classes, properties, and methods have no special marking. The main 
 components of the API are shown below:
 
 <img width="100%" src="diagrams/class_diagram.svg" alt="Async Jobs Timing Diagram"/>

--- a/specification.md
+++ b/specification.md
@@ -1602,13 +1602,15 @@ attributes or not. It is, therefore, entirely possible for
 ### StageInSet
 
 This class represents a set of stage-in directives, each represented by a 
-[`StageIn`](#stagein) object, that have no particular order. 
+[`StageIn`](#stagein) object, that have no particular order.
 
 <div class="imp-note">
 
-In languages with generic types and a `Set` type, a staging set could
-simply be `Set<StageIn>`, but implementations have the liberty to
-implement a specialized class that exposes the same essential functionality.
+Implementations must use what is customary for the language in which this
+specification is implemented. For example, in languages where a generic `Set`
+type is provided, implementations must use that instead of a custom 
+`StageInSet` class. When a ganeric `Set` is not available, implementations must
+ensure that the `StageInSet` class contains relevant accessor methods.
 
 </div>
 
@@ -1620,21 +1622,7 @@ implement a specialized class that exposes the same essential functionality.
 StageInSet()
 ```
 
-Constructs an empty stage-in set. 
-
-<div class="imp-note">
-
-For implementations that use a generic set, such as `Set<StageIn>`, a default
-`Set` constructor are considered to fulfill the contract of this API.
-Implementations are encouraged to provide convenience constructors that allow
-the specification of staging set entries as constructor parameters. If such a
-constructor is provided, implementations may elect to eschew mutating methods,
-such as entry removal. Implementations must, however, provide relevant
-accessor/iterator methods based on what is customary for the language being
-used.
-
-</div>
-
+Constructs an empty stage-in set.
 
 #### Methods
 
@@ -1653,9 +1641,11 @@ This class represents a set of stage-out directives, each represented by a
 
 <div class="imp-note">
 
-In languages with generic types and a `Set` type, a staging set could
-simply be `Set<StageOut>`, but implementations have the liberty to
-implement a specialized class that exposes the same essential functionality.
+Implementations must use what is customary for the language in which this
+specification is implemented. For example, in languages where a generic `Set`
+type is provided, implementations must use that instead of a custom 
+`StageOutSet` class. When a ganeric `Set` is not available, implementations must
+ensure that the `StageOutSet` class contains relevant accessor methods.
 
 </div>
 
@@ -1668,20 +1658,6 @@ StageOutSet()
 ```
 
 Constructs an empty stage-out set. 
-
-<div class="imp-note">
-
-For implementations that use a generic set, such as `Set<StageOut>`, a default
-`Set` constructor are considered to fulfill the contract of this API.
-Implementations are encouraged to provide convenience constructors that allow
-the specification of staging set entries as constructor parameters. If such a
-constructor is provided, implementations may elect to eschew mutating methods,
-such as entry removal. Implementations must, however, provide relevant
-accessor/iterator methods based on what is customary for the language being
-used.
-
-</div>
-
 
 #### Methods
 
@@ -1712,9 +1688,11 @@ that point to files or directories that are outside the job directory.
 
 <div class="imp-note">
 
-In languages with generic types and a `Set` type, a staging set could simply be
-`Set<Path>`, but implementations have the liberty to implement a specialized
-class that exposes the same essential functionality.
+Implementations must use what is customary for the language in which this
+specification is implemented. For example, in languages where a generic `Set`
+type is provided, implementations must use that instead of a custom 
+`StageOutSet` class. When a ganeric `Set` is not available, implementations must
+ensure that the `StageOutSet` class contains relevant accessor methods.
 
 </div>
 
@@ -1727,20 +1705,6 @@ CleanupSet()
 ```
 
 Constructs an empty cleanup set. 
-
-<div class="imp-note">
-
-For implementations that use a generic set, such as `Set<Path>`, a default 
-`Set` constructor are considered to fulfill the contract of this API. 
-Implementations are encouraged to provide convenience constructors that allow 
-the specification of staging set entries as constructor parameters. If such a 
-constructor is provided, implementations may elect to eschew mutating methods, 
-such as entry removal. Implementations must, however, provide relevant 
-accessor/iterator methods based on what is customary for the language being 
-used.
-
-</div>
-
 
 #### Methods
 

--- a/specification.md
+++ b/specification.md
@@ -310,6 +310,10 @@ explicit runtime type-checks, but it is not required to do so.
 - Getters/setters can be replaced by properties, depending on what is customary 
 in the language in which the library is implemented.
 
+- Implementations may elect, at their discretion, to implement many of the 
+classes described in this document as read-only classes for which all 
+properties are set at construction time. 
+
 
 <div class="imp-note">
 

--- a/specification.md
+++ b/specification.md
@@ -607,12 +607,12 @@ following state model:
   - A job is created in an initial state `NEW`.  
   - When the job is accepted by the backend for execution, it will enter the 
   state `QUEUED`.
-  - Before the job starts executing, it enters the 
+  - Before job execution starts, it enters the
   `STAGE_IN` state and remains in that state until all files in the stage-in 
   set are staged in.
   - When the job is being executed and consumes resources, it enters the 
   `ACTIVE` state.
-  - After the job ends, it enters the `STAGE_OUT` state and 
+  - After job execution ends, it enters the `STAGE_OUT` state and
   remains in that state until all files in the stage-out set are staged out.
   - After staging completes, the job enters the `CLEAN_UP`
   state


### PR DESCRIPTION
This adds file staging as part of Layer 0.

File staging was initially part of Layer 1, but there is reasonable reason for existing Layer 0 executors to support file staging.
For example, the local executor is useful as a test executor and should support staging in order to allow testing of software without the complexity of remote execution. Another example is PBS, which natively supports staging directives in submit scripts.

There are some other changes, such as the removal of the "early draft" status and a move to something that is closer to a change log.