### PR TITLE
Add and fix python constructors

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -813,13 +813,17 @@ In Python, the default constructor is replaced with the following constructor:
 
 <a name="jobspec-_**"></a>
 ```python
-JobSpec(executable: str = None, arguments: List[str] = None, 
-        directory: Path = None, name: str = None,
+JobSpec(executable: Optional[str] = None,
+        arguments: Optional[List[str]] = None,
+        directory: Optional[Path] = None,
+        name: Optional[str] = None,
         inherit_environment: bool = True,
-        environment: Dict[str, str] = None, stdin_path: Path = None,
-        stdout_path: Path = None, stderr_path: Path = None,
-        resources: ResourceSpec = None,
-        attributes: JobAttributes = None)
+        environment: Optional[Dict[str, str]] = None,
+        stdin_path: Optional[Path] = None,
+        stdout_path: Optional[Path] = None,
+        stderr_path: Optional[Path] = None,
+        resources: Optional[ResourceSpec] = None,
+        attributes: Optional[JobAttributes] = None)
 ```
 
 Creates an instance of `JobSpec` which allows properties to be initialized

--- a/specification.md
+++ b/specification.md
@@ -1444,6 +1444,25 @@ JobAttributes()
 
 Constructs an empty `JobAttributes` object.
 
+__Python__:
+
+In Python, the default constructor is replaced with the following constructor:
+
+<a name="resourcespecv1-_**"></a>
+```python
+JobAttributes(duration: Optional[TimeInterval] = none,
+              queue_name: Optional[str] = none,
+              project_name: Optional[str] = None,
+              reservation_id: Optional[str] = None,
+              custom_attributes: Optional[Dict[str, object]] = None)
+```
+
+A constructor for `JobAttributes` which allows properties to be initialized
+through keyword arguments.
+
+</div>
+
+
 #### Methods
 
 <a name="jobattributes-setduration"></a>

--- a/specification.md
+++ b/specification.md
@@ -813,8 +813,8 @@ In Python, the default constructor is replaced with the following constructor:
 
 <a name="jobspec-_**"></a>
 ```python
-JobSpec(name: str = None, executable: str = None,
-        arguments: List[str] = None, directory: Path = None,
+JobSpec(executable: str = None, arguments: List[str] = None, 
+        directory: Path = None, name: str = None,
         inherit_environment: bool = True,
         environment: Dict[str, str] = None, stdin_path: Path = None,
         stdout_path: Path = None, stderr_path: Path = None,


### PR DESCRIPTION
This adds a Python constructor for `JobAttributes`, in line with other classes, such as `JobSpec` and `ResourceSpecV1` (fixes #161).

It also fixes the type declarations for `JobSpec`.