### PR TITLE
Example fixes

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1943,7 +1943,7 @@ job.wait()
 ```python
 import psij
 
-res_spec = psij.ResourceSpec()
+res_spec = psij.ResourceSpecV1()
 res_spec.process_count     = 10
 res_spec.cores_per_process = 4
 res_spec.gpus_per_process  = 1
@@ -1975,7 +1975,7 @@ access to the nodes.
 ```python
 import psij
 
-res_spec = psij.ResourceSpec()
+res_spec = psij.ResourceSpecV1()
 res_spec.exclusive_nodes = true
 res_spec.process_count = 10
 res_spec.processes__per_node = 2

--- a/specification.md
+++ b/specification.md
@@ -1839,6 +1839,7 @@ submitted jobs complete in order to keep the running number of jobs at `M`.
 
 ```python
 import psij
+import threading
 
 class ThrottledSubmitter:
     def __init__(self):
@@ -1846,14 +1847,16 @@ class ThrottledSubmitter:
         # keep track of completed jobs so that we can submit the rest
         self.jex.set_job_status_callback(self.callback)
         self.count = 0
+        self.lock = threading.RLock()
 
     def make_job(self):
         ...
 
     def submit_next():
-        if self.count < N:
-            self.jex.submit(self.jobs[self.count])
-            self.count += 1
+        with self.lock:
+          if self.count < N:
+              self.jex.submit(self.jobs[self.count])
+              self.count += 1
 
     def start(self)
         # create list of jobs


### PR DESCRIPTION
The throttling example could occasionally lead to re-submission of the same job (because the counter increment wasn't protected by a critical section). This fixes it (fixes #163).

It also replaces some instantiations of `ResourceSpec` (which is abstract and cannot be instantiated) to `ResourceSpecV1` (this fixes #165).